### PR TITLE
spec: add requires on systemd

### DIFF
--- a/headscale.spec
+++ b/headscale.spec
@@ -45,6 +45,8 @@ BuildRequires:  git-core
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  tar
 
+Requires: systemd
+
 %description %{common_description}
 
 


### PR DESCRIPTION
If trying to run headscale within a container the systemd package is likely not installed already. We clearly depend on it for this RPM so let's name the dependency.